### PR TITLE
Added modification to suppress runtime warning but keep function the same

### DIFF
--- a/brainmodel_utils/metrics/consistency.py
+++ b/brainmodel_utils/metrics/consistency.py
@@ -38,9 +38,15 @@ def get_consistency_per_neuron(X, Y, X1, X2, Y1, Y2, metric="pearsonr"):
     r_yy = metric_func(Y1, Y2)[0]
     r_yy_sb = sb_correction(r_yy)
 
-    denom_sb = (r_xx_sb * r_yy_sb) ** 0.5
-
-    r_xy_n_sb = r_xy / denom_sb
+    # Check if the product is negative or close to zero to avoid runtime warning
+    # functionally, the code is the same as before, since when the denominator is complex or zero, r_xy_n_sb is still NaN
+    r_product = r_xx_sb * r_yy_sb
+    if (r_product < 0) or np.isclose(r_product, 0):
+        denom_sb = np.nan
+        r_xy_n_sb = np.nan
+    else:
+        denom_sb = (r_product) ** 0.5
+        r_xy_n_sb = r_xy / denom_sb
 
     reg_metrics = {
         "r_xy_n_sb": r_xy_n_sb,
@@ -55,7 +61,16 @@ def get_consistency_per_neuron(X, Y, X1, X2, Y1, Y2, metric="pearsonr"):
 
 
 def get_linregress_consistency_persplit(
-    X, Y, X1, X2, Y1, Y2, map_kwargs, train_idx, test_idx, metric="pearsonr",
+    X,
+    Y,
+    X1,
+    X2,
+    Y1,
+    Y2,
+    map_kwargs,
+    train_idx,
+    test_idx,
+    metric="pearsonr",
 ):
     assert "rsa" not in metric
     if map_kwargs is None:
@@ -214,7 +229,6 @@ def get_linregress_consistency(
     start_seed=1234,
     **kwargs
 ):
-
     """
     The main function for computing the linear regression consistency (noise corrected)
     between source and target.

--- a/brainmodel_utils/metrics/consistency.py
+++ b/brainmodel_utils/metrics/consistency.py
@@ -39,7 +39,9 @@ def get_consistency_per_neuron(X, Y, X1, X2, Y1, Y2, metric="pearsonr"):
     r_yy_sb = sb_correction(r_yy)
 
     # Check if the product is negative or close to zero to avoid runtime warning
-    # functionally, the code is the same as before, since when the denominator is complex or zero, r_xy_n_sb is still NaN
+    # functionally, the code is the same as before, since when the denominator is complex or zero, then r_xy_n_sb is still NaN
+    # this should be the case since the metric's derivation is theoretically undefined if r_xx and r_yy are negative,
+    # as transitive property of correlation is no longer guaranteed in this case
     r_product = r_xx_sb * r_yy_sb
     if (r_product < 0) or np.isclose(r_product, 0):
         denom_sb = np.nan

--- a/brainmodel_utils/neural_mappers/percentile_neural_map.py
+++ b/brainmodel_utils/neural_mappers/percentile_neural_map.py
@@ -151,7 +151,6 @@ class PercentileNeuralMap(nm.NeuralMapBase):
         ), f"Number of train features ({self._n_source}) does not align with number of test features ({X.shape[1]})"
 
         n_samples = X.shape[0]
-        #preds = np.empty((n_samples, self._n_targets)) + np.NaN
         preds = np.full((n_samples, self._n_targets), np.nan)
         for i, mapper in enumerate(self._mappers):
             if self._identity:

--- a/brainmodel_utils/neural_mappers/percentile_neural_map.py
+++ b/brainmodel_utils/neural_mappers/percentile_neural_map.py
@@ -151,7 +151,8 @@ class PercentileNeuralMap(nm.NeuralMapBase):
         ), f"Number of train features ({self._n_source}) does not align with number of test features ({X.shape[1]})"
 
         n_samples = X.shape[0]
-        preds = np.empty((n_samples, self._n_targets)) + np.NaN
+        #preds = np.empty((n_samples, self._n_targets)) + np.NaN
+        preds = np.full((n_samples, self._n_targets), np.nan)
         for i, mapper in enumerate(self._mappers):
             if self._identity:
                 assert isinstance(mapper, np.int64)  # mapper contains the source index

--- a/brainmodel_utils/neural_mappers/pls_neural_map.py
+++ b/brainmodel_utils/neural_mappers/pls_neural_map.py
@@ -98,7 +98,7 @@ class PLSNeuralMap(nm.NeuralMapBase):
             if self._fit_per_target_unit:
                 assert isinstance(self._pls, list) is True
                 assert len(self._pls) == self._n_targets
-                #preds = np.empty((n_samples, self._n_targets)) + np.NaN
+
                 preds = np.full((n_samples, self._n_targets), np.nan)
                 for i, curr_pls in enumerate(self._pls):
                     if curr_pls is not None:
@@ -111,7 +111,7 @@ class PLSNeuralMap(nm.NeuralMapBase):
             assert self._pls is None
             if self._verbose:
                 print(f"[WARNING] PLS regression fitting failed.")
-            #preds = np.zeros((n_samples, self._n_targets)) + np.NaN
+
             preds = np.full((n_samples, self._n_targets), np.nan)
 
         return preds

--- a/brainmodel_utils/neural_mappers/pls_neural_map.py
+++ b/brainmodel_utils/neural_mappers/pls_neural_map.py
@@ -98,7 +98,8 @@ class PLSNeuralMap(nm.NeuralMapBase):
             if self._fit_per_target_unit:
                 assert isinstance(self._pls, list) is True
                 assert len(self._pls) == self._n_targets
-                preds = np.empty((n_samples, self._n_targets)) + np.NaN
+                #preds = np.empty((n_samples, self._n_targets)) + np.NaN
+                preds = np.full((n_samples, self._n_targets), np.nan)
                 for i, curr_pls in enumerate(self._pls):
                     if curr_pls is not None:
                         curr_pred = curr_pls.predict(X).flatten()
@@ -110,6 +111,7 @@ class PLSNeuralMap(nm.NeuralMapBase):
             assert self._pls is None
             if self._verbose:
                 print(f"[WARNING] PLS regression fitting failed.")
-            preds = np.zeros((n_samples, self._n_targets)) + np.NaN
+            #preds = np.zeros((n_samples, self._n_targets)) + np.NaN
+            preds = np.full((n_samples, self._n_targets), np.nan)
 
         return preds


### PR DESCRIPTION
Suppresses runtime warning by catching NaN scenarios, which automatically happen when dividing by a complex number (due to product being negative), or dividing by 0.